### PR TITLE
EqualErrorへ修正したときにテストが正しく行われていないことから第三引数が間違られていたため、errorではなくstringを渡す…

### DIFF
--- a/bottles/storage_test.go
+++ b/bottles/storage_test.go
@@ -1,7 +1,6 @@
 package bottles
 
 import (
-	"fmt"
 	"time"
 	"testing"
 	"context"
@@ -28,7 +27,7 @@ func TestGetMessageFromEmptyStorage(t *testing.T) {
 	storage := NewMessageStorage()
 
 	message, err := storage.Get()
-	assert.EqualError(t, err, fmt.Errorf("No Messages"))
+	assert.EqualError(t, err, "No Messages")
 	assert.Nil(t, message)
 }
 
@@ -133,7 +132,7 @@ func TestTokenStorageInvalidToken(t *testing.T) {
 	}
 
 	err := storage.Use(token)
-	assert.EqualError(t, err, fmt.Errorf("Token is Invalid"))
+	assert.EqualError(t, err, "Token is Invalid")
 }
 
 func TestTokenStorageSameToken(t *testing.T) {
@@ -151,7 +150,7 @@ func TestTokenStorageSameToken(t *testing.T) {
 
 	_ = storage.Add(token1)
 	err := storage.Add(token2)
-	assert.EqualError(t, err, fmt.Errorf("Storage has Same Token"))
+	assert.EqualError(t, err, "Storage has Same Token")
 }
 
 func TestTokenStorageTokenExpiration(t *testing.T) {
@@ -167,7 +166,7 @@ func TestTokenStorageTokenExpiration(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	err := storage.Use(token)
 
-	assert.EqualError(t, err, fmt.Errorf("Token is Invalid"))
+	assert.EqualError(t, err, "Token is Invalid")
 }
 
 func TestTokenStorageAddNilToken(t *testing.T) {
@@ -178,5 +177,5 @@ func TestTokenStorageAddNilToken(t *testing.T) {
 
 	err := storage.Add(token)
 
-	assert.EqualError(t, err, fmt.Errorf("Token is Empty"))
+	assert.EqualError(t, err, "Token is Empty")
 }


### PR DESCRIPTION
…ようにする